### PR TITLE
[WiP] Pass argument to entrypoint as a single string

### DIFF
--- a/neurodocker/generate.py
+++ b/neurodocker/generate.py
@@ -352,7 +352,7 @@ def _add_common_dependencies(pkg_manager):
             '\n&& if [ ! -f "$ND_ENTRYPOINT" ]; then'
             "\n     echo '#!/usr/bin/env bash' >> $ND_ENTRYPOINT"
             "\n     && echo 'set +x' >> $ND_ENTRYPOINT"
-            "\n     && echo 'if [ -z \"$*\" ]; then /usr/bin/env bash; else $*; fi' >> $ND_ENTRYPOINT;"
+            "\n     && echo 'if [ -z \"$*\" ]; then /usr/bin/env bash; else "$*"; fi' >> $ND_ENTRYPOINT;"
             "\n   fi"
             "\n&& chmod -R 777 /neurodocker && chmod a+s /neurodocker")
     cmd = indent("RUN", cmd)


### PR DESCRIPTION
`"$*"` instead of `$*`

otherwise this causes commands like `"bash -c echo life is good"` to fail because the elements are passed individually.

I noticed there are some test to modify -- I'll get back to this ASAP :)